### PR TITLE
Renamed directory name from `data_util/face_tracking` to `data_utils/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install tensorflow-gpu==2.8.0
 
   ```
   cp 01_MorphableModel.mat data_util/face_tracking/3DMM/
-  cd data_util/face_tracking
+  cd data_utils/face_tracking
   python convert_BFM.py
   ```
 


### PR DESCRIPTION
Upon correcting the directory name, I executed the related command `cd data_utils/face_tracking` and can now successfully access the `data_utils/face_tracking` directory without encountering a "path not found" error.